### PR TITLE
fix: NPM CI Node version

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Install Rush
       run: pnpm install -g @microsoft/rush


### PR DESCRIPTION
Resolves an incompatibility with our new `rush.json` introduced in #184, as can be seen in the [last job run](https://github.com/meese-os/meeseOS/actions/runs/17924998756/job/50968776595).